### PR TITLE
Document "sudo docker" and podman, and enter in /app directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,6 @@ RUN git clone --branch nanos-160 https://github.com/LedgerHQ/nanos-secure-sdk.gi
 
 ENV BOLOS_SDK=/sdk
 
+WORKDIR /app
+
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
 # Ledger Application Builder
 
-This Docker image contains every dependencies to compile an application for the Nano S.
+This container image contains all dependencies to compile an application for the Nano S.
 
-## Build the docker image
+## Build the container image
 
-```
-$ docker build -t ledger-app-builder:1.6.0 .
+Several tools are available to build a container image:
+```sh
+# Docker
+sudo docker build -t ledger-app-builder:1.6.0 .
+
+# Podman (from https://podman.io/)
+podman build -t ledger-app-builder:1.6.0 .
+
+# Buildah (from https://buildah.io/)
+buildah bud -t ledger-app-builder:1.6.0 .
 ```
 
 ## Compile your app
 
 In the source folder of your Nano S application:
 
-```
-$ docker run -ti -v $(realpath .):/app ledger-app-builder:1.6.0
-root@656be163fe84:/# cd app/ && make
+```console
+$ sudo docker run --rm -ti -v "$(realpath .):/app" ledger-app-builder:1.6.0
+root@656be163fe84:/app# make
+
+$ podman run --rm -ti -v "$(realpath .):/app" ledger-app-builder:1.6.0
+root@1f4f60f535fa:/app# ls
 ```


### PR DESCRIPTION
Using Docker as an unprivileged user may introduce security issues. Document using `sudo docker` instead, which makes it clearer that using `docker` requires privileges.

Nowadays, there also exists `podman`, which is great for people who do not want to type their `sudo` password everytime they run `docker`. Its CLI is similar to Docker, but document it nonetheless.

Add a `WORKDIR` directive to `Dockerfile` in order to avoid requiring to `cd /app` everytime the container is launched.

Finally, quotes shell arguments properly (in case `$(realpath .)` contains spaces) and use `--rm` to remove the container when it ends.