### PR TITLE
Install clang-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV LANG C.UTF-8
 RUN apt-get update && apt-get upgrade -qy && \
   apt-get install -qy \
     clang \
+    clang-tools \
     gcc-multilib \
     gcc-arm-none-eabi \
     libc6-dev-armhf-cross \

--- a/README.md
+++ b/README.md
@@ -25,5 +25,11 @@ $ sudo docker run --rm -ti -v "$(realpath .):/app" ledger-app-builder:1.6.0
 root@656be163fe84:/app# make
 
 $ podman run --rm -ti -v "$(realpath .):/app" ledger-app-builder:1.6.0
-root@1f4f60f535fa:/app# ls
+root@1f4f60f535fa:/app# make
+```
+
+The Docker image includes the [Clang Static Analyzer](https://clang-analyzer.llvm.org/), that can be invoked with:
+```sh
+podman run --rm -ti -v "$(realpath .):/app" ledger-app-builder:1.6.0 \
+    scan-build --use-cc=clang -analyze-headers -o /app/output-scan-build make
 ```


### PR DESCRIPTION
Package `clang-tools` provides Clang Static Analyze (command `scan-build`), which is useful to ensure there is no bug in applications by running:

    scan-build --use-cc=clang -analyze-headers make

Document this in the README.