### PR TITLE
Update to SDK 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN \
   rm -rf cmoka/ cmocka-1.1.5/ cmocka-1.1.5.tar.xz SHA256SUMS
 
 # Nano S SDK
-RUN cd /opt && git clone --branch nanos-1612 https://github.com/LedgerHQ/nanos-secure-sdk.git nanos-secure-sdk
+RUN cd /opt && git clone --depth 1 --branch 2.0.0-1 https://github.com/LedgerHQ/nanos-secure-sdk.git nanos-secure-sdk
 
 ENV BOLOS_SDK=/opt/nanos-secure-sdk
 


### PR DESCRIPTION
This PR:
1. Updates the SDK version to use the latest (2.0.0-1) one.
2. Adds `--depth 1` to the `git clone` command in order to skip history cloning.