### PR TITLE
use curl instead of wget in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,13 @@ RUN apt-get update && apt-get upgrade -qy && \
         python-is-python3 \
         python3 \
         python3-pip \
-        wget && \
     apt-get autoclean -y && \
     apt-get autoremove -y && \
     apt-get clean
 
 # ARM Embedded Toolchain
 # Integrity is checked using the MD5 checksum provided by ARM at https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads
-RUN wget -O arm-toolchain.tar.bz2 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2?revision=ca0cbf9c-9de2-491c-ac48-898b5bbc0443&la=en&hash=68760A8AE66026BCF99F05AC017A6A50C6FD832A" && \
+RUN curl -sSfL -o arm-toolchain.tar.bz2 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2?revision=ca0cbf9c-9de2-491c-ac48-898b5bbc0443&la=en&hash=68760A8AE66026BCF99F05AC017A6A50C6FD832A" && \
     echo 8312c4c91799885f222f663fc81f9a31 arm-toolchain.tar.bz2 > /tmp/arm-toolchain.md5 && \
     md5sum --check /tmp/arm-toolchain.md5 && rm /tmp/arm-toolchain.md5 && \
     tar xf arm-toolchain.tar.bz2 -C /opt && \


### PR DESCRIPTION
Wget's output wasn't turned off and that pollutes the log.

Since curl is already used in this script, make use of it and remove that
dependency. Regarding the options (-sSfL), here is the long form: --silent
--show-error --fail-early and --location. -L is required because the server
returns a 302 HTTP status.