### PR TITLE
Support multi-arch amd64 & arm64 builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Clone
       uses: actions/checkout@v2
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Build and push ledger-app-builder to GitHub Packages
       uses: docker/build-push-action@v1
       with:
@@ -31,3 +37,5 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
         tag_with_sha: true
         tags: latest
+        platforms: linux/amd64,linux/arm64
+        push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,24 @@ RUN apt-get update && apt-get upgrade -qy && \
 
 # ARM Embedded Toolchain
 # Integrity is checked using the MD5 checksum provided by ARM at https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads
-RUN curl -sSfL -o arm-toolchain.tar.bz2 "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2" && \
-    echo 2383e4eb4ea23f248d33adc70dc3227e arm-toolchain.tar.bz2 > /tmp/arm-toolchain.md5 && \
+ENV TOOLCHAIN_VERSION 10.3-2021.10
+RUN case $(uname -m) in \
+        x86_64 | amd64) \
+            ARCH=x86_64 \
+            MD5=2383e4eb4ea23f248d33adc70dc3227e;; \
+        aarch64 | arm64) \
+            ARCH=aarch64; \
+            MD5=3fe3d8bb693bd0a6e4615b6569443d0d;; \
+        *) echo "Unkown architecture" && exit 1;; \
+    esac && \
+    curl -sSfL -o arm-toolchain.tar.bz2 "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/${TOOLCHAIN_VERSION}/gcc-arm-none-eabi-${TOOLCHAIN_VERSION}-${ARCH}-linux.tar.bz2" && \
+    echo ${MD5} arm-toolchain.tar.bz2 > /tmp/arm-toolchain.md5 && \
     md5sum --check /tmp/arm-toolchain.md5 && rm /tmp/arm-toolchain.md5 && \
     tar xf arm-toolchain.tar.bz2 -C /opt && \
     rm arm-toolchain.tar.bz2
 
 # Adding GCC to PATH and defining rustup/cargo home directories
-ENV PATH=/opt/gcc-arm-none-eabi-10.3-2021.10/bin:$PATH \
+ENV PATH=/opt/gcc-arm-none-eabi-${TOOLCHAIN_VERSION}/bin:$PATH \
     RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/.cargo
 


### PR DESCRIPTION
Adds support for multi-arch `amd64` & `arm64` builds using `buildx`.

See: https://docs.docker.com/desktop/multi-arch/