### PR TITLE
Update Nano X SDK to 2.0.2-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,12 @@ RUN rustup target add thumbv6m-none-eabi
 RUN pip3 install ledgerblue pytest
 
 # Latest Nano S SDK
-RUN cd /opt && git clone --branch 2.1.0 https://github.com/LedgerHQ/nanos-secure-sdk.git nanos-secure-sdk
 ENV NANOS_SDK=/opt/nanos-secure-sdk
+RUN git clone --branch 2.1.0 --depth 1 https://github.com/LedgerHQ/nanos-secure-sdk.git "${NANOS_SDK}"
 
 # Latest Nano X SDK
-RUN cd /opt && git clone --branch 2.0.0 https://github.com/LedgerHQ/nanox-secure-sdk.git nanox-secure-sdk
 ENV NANOX_SDK=/opt/nanox-secure-sdk
+RUN git clone --branch 2.0.0 --depth 1 https://github.com/LedgerHQ/nanox-secure-sdk.git "${NANOX_SDK}"
 
 # Default SDK
 ENV BOLOS_SDK=${NANOS_SDK}

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN git clone --branch 2.1.0 --depth 1 https://github.com/LedgerHQ/nanos-secure-
 
 # Latest Nano X SDK
 ENV NANOX_SDK=/opt/nanox-secure-sdk
-RUN git clone --branch 2.0.0 --depth 1 https://github.com/LedgerHQ/nanox-secure-sdk.git "${NANOX_SDK}"
+RUN git clone --branch 2.0.2-1 --depth 1 https://github.com/LedgerHQ/nanox-secure-sdk.git "${NANOX_SDK}"
 
 # Default SDK
 ENV BOLOS_SDK=${NANOS_SDK}

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ ENV BOLOS_SDK=${NANOS_SDK}
 
 WORKDIR /app
 
-CMD ["/bin/bash"]
+CMD ["/usr/bin/env", "bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get upgrade -qy && \
     apt-get install -qy \
         clang \
         clang-tools \
+        clang-format \
         cmake \
         curl \
         doxygen \


### PR DESCRIPTION
* Minimal amount of git history is now cloned with the SDKs
* Update to LNX SDK 2.0.2-1
* Added missing dependency to clang-format (there would always be a warning about it when building an app)