### PR TITLE
ARM toolchain for Linux aarch64 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get upgrade -qy && \
 
 # ARM Embedded Toolchain
 # Integrity is checked using the MD5 checksum provided by ARM at https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads
-RUN curl -sSfL -o arm-toolchain.tar.bz2 "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2" && \
-    echo 2383e4eb4ea23f248d33adc70dc3227e arm-toolchain.tar.bz2 > /tmp/arm-toolchain.md5 && \
+RUN curl -SfL -o arm-toolchain.tar.bz2 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-aarch64-linux.tar.bz2" && \
+    echo 3fe3d8bb693bd0a6e4615b6569443d0d arm-toolchain.tar.bz2 > /tmp/arm-toolchain.md5 && \
     md5sum --check /tmp/arm-toolchain.md5 && rm /tmp/arm-toolchain.md5 && \
     tar xf arm-toolchain.tar.bz2 -C /opt && \
     rm arm-toolchain.tar.bz2
@@ -40,7 +40,7 @@ ENV PATH=/opt/gcc-arm-none-eabi-10.3-2021.10/bin:$PATH \
     CARGO_HOME=/opt/.cargo
 
 # Install rustup to manage rust toolchains
-RUN curl https://sh.rustup.rs -sSf | \
+RUN curl https://sh.rustup.rs -Sf | \
     sh -s -- --default-toolchain stable -y
 
 # Adding cargo binaries to PATH


### PR DESCRIPTION
When running Docker container on a Linux 64-bit ARM architecture (for instance Ubuntu VM launched by multipass on Mac M1), proper ARM toolchain shall be downloaded.