### PR TITLE
Upgrade to Ubuntu 22.04 and LLVM 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV LANG C.UTF-8
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG LLVM_VERSION=12
+ARG LLVM_VERSION=14
 
 RUN apt-get update && apt-get upgrade -qy && \
     apt-get install -qy \


### PR DESCRIPTION
This PR upgrades image to use the latest LTS version of Ubuntu (22.04).

It also upgrades LLVM from 12 to 14, which is the default version used by Ubuntu 22.04.