### PR TITLE
Alpine based + multi-arch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,33 +1,53 @@
 # Build the docker image and push it to GitHub Packages
 
-name: Ledger App Builder Publisher
+name: Publish Docker images
 
 on:
   push:
     branches:
       - master
-    paths:
-      - .github/workflows/publish.yml
-      - Dockerfile
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PATH: ${{ github.repository }}
 
 jobs:
-  build:
-    name: Build and push ledger-app-builder image
+  builder_lite:
+    name: App Builder Lite
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    env:
+      IMAGE_NAME: ledger-app-builder-lite
 
     steps:
-    - name: Clone
-      uses: actions/checkout@v2
+      - name: Clone
+        uses: actions/checkout@v3
 
-    - name: Build and push ledger-app-builder to GitHub Packages
-      uses: docker/build-push-action@v1
-      with:
-        dockerfile: Dockerfile
-        repository: ledgerhq/ledger-app-builder/ledger-app-builder
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        tag_with_sha: true
-        tags: latest
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}
+
+      - name: Set-up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set-up Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push container
+        uses: docker/build-push-action@v3
+        with:
+          file: lite/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:${{ github.sha }},${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,26 @@ env:
   IMAGE_PATH: ${{ github.repository }}
 
 jobs:
+  mods_list:
+    name: Get modified files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changes
+        id: get-changes
+        uses: tj-actions/changed-files@v28
+    outputs:
+      modified_files: ${{ steps.get-changes.outputs.modified_files }}
+
   builder_lite:
     name: App Builder Lite
     runs-on: ubuntu-latest
+    needs: mods_list
+    if: contains(needs.mods_list.outputs.modified_files, 'lite/Dockerfile')
     permissions:
       packages: write
     env:
@@ -55,7 +72,8 @@ jobs:
   builder:
     name: App Builder
     runs-on: ubuntu-latest
-    needs: builder_lite
+    needs: [mods_list, builder_lite]
+    if: always() && (needs.builder_lite.result != 'skipped' || contains(needs.mods_list.outputs.modified_files, 'Dockerfile'))
     permissions:
       packages: write
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,3 +51,44 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:${{ github.sha }},${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
           push: true
+
+  builder:
+    name: App Builder
+    runs-on: ubuntu-latest
+    needs: builder_lite
+    permissions:
+      packages: write
+    env:
+      IMAGE_NAME: ledger-app-builder
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}
+
+      - name: Set-up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set-up Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push container
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:${{ github.sha }},${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,7 @@ jobs:
     name: App Builder
     runs-on: ubuntu-latest
     needs: [mods_list, builder_lite]
-    if: always() && (needs.builder_lite.result != 'skipped' || contains(needs.mods_list.outputs.modified_files, 'Dockerfile'))
+    if: always() && (needs.builder_lite.result == 'success' || (needs.builder_lite.result == 'skipped' && contains(needs.mods_list.outputs.modified_files, 'Dockerfile')))
     permissions:
       packages: write
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# Build the docker image and push it to GitHub Packages
+# Build the docker images and push them to GitHub Packages
 
 name: Publish Docker images
 
@@ -10,6 +10,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_PATH: ${{ github.repository }}
+  BUILD_PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   mods_list:
@@ -35,7 +36,7 @@ jobs:
     permissions:
       packages: write
     env:
-      IMAGE_NAME: ledger-app-builder-lite
+      IMAGE_NAME: ${{ github.event.repository.name }}-lite
 
     steps:
       - name: Clone
@@ -44,7 +45,7 @@ jobs:
       - name: Login to registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,10 +63,12 @@ jobs:
 
       - name: Build and push container
         uses: docker/build-push-action@v3
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}
         with:
           file: lite/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:${{ github.sha }},${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:latest
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          tags: ${{ env.IMAGE }}:${{ github.sha }},${{ env.IMAGE }}:latest
           labels: ${{ steps.meta.outputs.labels }}
           push: true
 
@@ -77,7 +80,7 @@ jobs:
     permissions:
       packages: write
     env:
-      IMAGE_NAME: ledger-app-builder
+      IMAGE_NAME: ${{ github.event.repository.name }}
 
     steps:
       - name: Clone
@@ -86,7 +89,7 @@ jobs:
       - name: Login to registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -104,9 +107,11 @@ jobs:
 
       - name: Build and push container
         uses: docker/build-push-action@v3
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}
         with:
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:${{ github.sha }},${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}/${{ env.IMAGE_NAME }}:latest
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          tags: ${{ env.IMAGE }}:${{ github.sha }},${{ env.IMAGE }}:latest
           labels: ${{ steps.meta.outputs.labels }}
           push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get changes
         id: get-changes
-        uses: tj-actions/changed-files@v28
+        uses: tj-actions/changed-files@v33
     outputs:
       modified_files: ${{ steps.get-changes.outputs.modified_files }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,7 @@ RUN apk add \
         git \
         python3 \
         py3-pip \
-        bash
-
-RUN apk add \
+        bash \
         gcc-arm-none-eabi \
         newlib-arm-none-eabi
 
@@ -24,9 +22,9 @@ RUN apk add \
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/.cargo
 
-# Install rustup to manage rust toolchains
-RUN wget -O - https://sh.rustup.rs | \
-    sh -s -- --default-toolchain stable -y
+RUN apk add rustup
+
+RUN rustup-init --default-toolchain stable -y
 
 # Adding cargo binaries to PATH
 ENV PATH=${CARGO_HOME}/bin:${PATH}
@@ -64,7 +62,7 @@ RUN git clone --branch 1.0.3 --depth 1 https://github.com/LedgerHQ/nanosplus-sec
 # Default SDK
 ENV BOLOS_SDK=${NANOS_SDK}
 
-# Cleanup
+# Cleanup, remove packages that aren't needed anymore
 RUN apk del $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,4 @@
-FROM alpine:3.15
-ENV LANG C.UTF-8
-
-RUN apk update
-RUN apk upgrade
-RUN apk add \
-        clang \
-        clang-extra-tools \
-        clang-analyzer \
-        lld \
-        cmake \
-        make \
-        doxygen \
-        git \
-        python3 \
-        py3-pip \
-        bash \
-        gcc-arm-none-eabi \
-        newlib-arm-none-eabi
+FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 
 # Define rustup/cargo home directories
 ENV RUSTUP_HOME=/opt/rustup \
@@ -31,42 +13,3 @@ ENV PATH=${CARGO_HOME}/bin:${PATH}
 
 # Adding ARMV6M target to the default toolchain
 RUN rustup target add thumbv6m-none-eabi
-
-# These packages contain shared libraries which will be needed at runtime
-RUN apk add \
-        libjpeg \
-        zlib \
-        eudev \
-        libusb
-
-# Python packages building dependencies, can be removed afterwards
-ARG PYTHON_BUILD_DEPS=python3-dev,musl-dev,libusb-dev,eudev-dev,linux-headers,zlib-dev,jpeg-dev
-
-RUN apk add $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')
-
-# Python package to load app onto device
-RUN pip3 install ledgerblue
-
-# Latest Nano S SDK
-ENV NANOS_SDK=/opt/nanos-secure-sdk
-RUN git clone --branch 2.1.0 --depth 1 https://github.com/LedgerHQ/nanos-secure-sdk.git "${NANOS_SDK}"
-
-# Latest Nano X SDK
-ENV NANOX_SDK=/opt/nanox-secure-sdk
-RUN git clone --branch 2.0.2-2 --depth 1 https://github.com/LedgerHQ/nanox-secure-sdk.git "${NANOX_SDK}"
-
-# Latest Nano S+ SDK
-ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
-RUN git clone --branch 1.0.3 --depth 1 https://github.com/LedgerHQ/nanosplus-secure-sdk.git "${NANOSP_SDK}"
-
-# Default SDK
-ENV BOLOS_SDK=${NANOS_SDK}
-
-# Cleanup, remove packages that aren't needed anymore
-RUN apk del $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')
-
-WORKDIR /app
-
-RUN git config --global --add safe.directory /app
-
-CMD ["/usr/bin/env", "bash"]

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -52,7 +52,7 @@ RUN git clone --branch 2.0.2-2 --depth 1 "$GIT_SERVER/nanox-secure-sdk.git" "$NA
 
 # Latest Nano S+ SDK
 ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
-RUN git clone --branch 1.0.3 --depth 1 "$GIT_SERVER/nanosplus-secure-sdk.git" "$NANOSP_SDK"
+RUN git clone --branch 1.0.4 --depth 1 "$GIT_SERVER/nanosplus-secure-sdk.git" "$NANOSP_SDK"
 
 # Default SDK
 ENV BOLOS_SDK=$NANOS_SDK

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -4,33 +4,33 @@ ENV LANG C.UTF-8
 RUN apk update
 RUN apk upgrade
 RUN apk add \
-        clang \
-        clang-extra-tools \
-        clang-analyzer \
-        lld \
-        cmake \
-        make \
-        doxygen \
-        git \
-        python3 \
-        py3-pip \
         bash \
+        clang \
+        clang-analyzer \
+        clang-extra-tools \
+        cmake \
+        doxygen \
         gcc-arm-none-eabi \
+        git \
+        lld \
+        make \
         newlib-arm-none-eabi \
-        protoc
+        protoc \
+        py3-pip \
+        python3
 
 # So that it still supports things incorrectly pointing to python
 RUN ln -s python3 $(dirname $(which python3))/python
 
 # These packages contain shared libraries which will be needed at runtime
 RUN apk add \
-        libjpeg \
-        zlib \
         eudev \
-        libusb
+        libjpeg \
+        libusb \
+        zlib
 
 # Python packages building dependencies, can be removed afterwards
-ARG PYTHON_BUILD_DEPS=python3-dev,musl-dev,libusb-dev,eudev-dev,linux-headers,zlib-dev,jpeg-dev
+ARG PYTHON_BUILD_DEPS=eudev-dev,jpeg-dev,libusb-dev,linux-headers,musl-dev,python3-dev,zlib-dev
 
 RUN apk add $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')
 

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -37,20 +37,22 @@ RUN apk add $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')
 # Python package to load app onto device
 RUN pip3 install ledgerblue
 
+ARG GIT_SERVER=https://github.com/LedgerHQ
+
 # Latest Nano S SDK
 ENV NANOS_SDK=/opt/nanos-secure-sdk
-RUN git clone --branch 2.1.0 --depth 1 https://github.com/LedgerHQ/nanos-secure-sdk.git "${NANOS_SDK}"
+RUN git clone --branch 2.1.0 --depth 1 "$GIT_SERVER/nanos-secure-sdk.git" "$NANOS_SDK"
 
 # Latest Nano X SDK
 ENV NANOX_SDK=/opt/nanox-secure-sdk
-RUN git clone --branch 2.0.2-2 --depth 1 https://github.com/LedgerHQ/nanox-secure-sdk.git "${NANOX_SDK}"
+RUN git clone --branch 2.0.2-2 --depth 1 "$GIT_SERVER/nanox-secure-sdk.git" "$NANOX_SDK"
 
 # Latest Nano S+ SDK
 ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
-RUN git clone --branch 1.0.3 --depth 1 https://github.com/LedgerHQ/nanosplus-secure-sdk.git "${NANOSP_SDK}"
+RUN git clone --branch 1.0.3 --depth 1 "$GIT_SERVER/nanosplus-secure-sdk.git" "$NANOSP_SDK"
 
 # Default SDK
-ENV BOLOS_SDK=${NANOS_SDK}
+ENV BOLOS_SDK=$NANOS_SDK
 
 # Cleanup, remove packages that aren't needed anymore
 RUN apk del $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -16,7 +16,8 @@ RUN apk add \
         py3-pip \
         bash \
         gcc-arm-none-eabi \
-        newlib-arm-none-eabi
+        newlib-arm-none-eabi \
+        protoc
 
 # So that it still supports things incorrectly pointing to python
 RUN ln -s python3 $(dirname $(which python3))/python

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -19,6 +19,9 @@ RUN apk add \
         py3-pip \
         python3
 
+# lcov is only present in the testing repository of the edge branch
+RUN apk add lcov --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+
 # So that it still supports things incorrectly pointing to python
 RUN ln -s python3 $(dirname $(which python3))/python
 

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -18,6 +18,9 @@ RUN apk add \
         gcc-arm-none-eabi \
         newlib-arm-none-eabi
 
+# So that it still supports things incorrectly pointing to python
+RUN ln -s python3 $(dirname $(which python3))/python
+
 # These packages contain shared libraries which will be needed at runtime
 RUN apk add \
         libjpeg \

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -1,0 +1,58 @@
+FROM alpine:3.15
+ENV LANG C.UTF-8
+
+RUN apk update
+RUN apk upgrade
+RUN apk add \
+        clang \
+        clang-extra-tools \
+        clang-analyzer \
+        lld \
+        cmake \
+        make \
+        doxygen \
+        git \
+        python3 \
+        py3-pip \
+        bash \
+        gcc-arm-none-eabi \
+        newlib-arm-none-eabi
+
+# These packages contain shared libraries which will be needed at runtime
+RUN apk add \
+        libjpeg \
+        zlib \
+        eudev \
+        libusb
+
+# Python packages building dependencies, can be removed afterwards
+ARG PYTHON_BUILD_DEPS=python3-dev,musl-dev,libusb-dev,eudev-dev,linux-headers,zlib-dev,jpeg-dev
+
+RUN apk add $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')
+
+# Python package to load app onto device
+RUN pip3 install ledgerblue
+
+# Latest Nano S SDK
+ENV NANOS_SDK=/opt/nanos-secure-sdk
+RUN git clone --branch 2.1.0 --depth 1 https://github.com/LedgerHQ/nanos-secure-sdk.git "${NANOS_SDK}"
+
+# Latest Nano X SDK
+ENV NANOX_SDK=/opt/nanox-secure-sdk
+RUN git clone --branch 2.0.2-2 --depth 1 https://github.com/LedgerHQ/nanox-secure-sdk.git "${NANOX_SDK}"
+
+# Latest Nano S+ SDK
+ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
+RUN git clone --branch 1.0.3 --depth 1 https://github.com/LedgerHQ/nanosplus-secure-sdk.git "${NANOSP_SDK}"
+
+# Default SDK
+ENV BOLOS_SDK=${NANOS_SDK}
+
+# Cleanup, remove packages that aren't needed anymore
+RUN apk del $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')
+
+WORKDIR /app
+
+RUN git config --global --add safe.directory /app
+
+CMD ["/usr/bin/env", "bash"]


### PR DESCRIPTION
Complete revamp of the app builder :tada: 

* Now based on Alpine Linux instead of Ubuntu (~600 MB less)
* Now gets all its packages straight from the repositories instead of manually downloading and installing some of them
* Thanks to the previous point, the Dockerfile becomes architecture-agnostic and the container is now generated for both linux/amd64 & linux/arm64 (simpler than #23)
* New base container suffixed with -lite, without the Rust environment so that apps that only use C can enjoy an even smaller container (extra ~1.3 GB less)
* New CI that builds both containers
* pytest removed from the container to keep it strictly focused on app-building