### PR TITLE
fix MESA-LOADER failure to open libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.7] - 2023-08-09
+
+### Changed
+    - Add mesa-dri-gallium package to dev-tools docker
+
 ## [3.2.6] - 2023-08-02
 
 ### Changed

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add libusb \
             qemu-arm \
             jq \
             curl \
-            tesseract-ocr
+            tesseract-ocr \
+            mesa-dri-gallium
 
 ARG QEMU_BIN=qemu-arm
 


### PR DESCRIPTION
Currently, when testing `app-boilerplate `using VSCode, executing `Run with Speculos`, I get the following output:
```
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-'
[*] speculos launcher revision: 
[*] using SDK version 6 on nanos
[*] loading CXLIB from "/usr/lib/python3.9/site-packages/speculos/cxlib/nanos-cx-2.1.elf"
[*] patching svc instruction at 0x126358
libGL error: MESA-LOADER: failed to open iris: Error loading shared library /usr/lib/xorg/modules/dri/iris_dri.so: No such file or directory (search paths /usr/lib/xorg/modules/dri, suffix _dri)
libGL error: failed to load driver: iris
[*] patching svc instruction at 0x40002038
[*] patching svc instruction at 0x40002046
libGL error: MESA-LOADER: failed to open swrast: Error loading shared library /usr/lib/xorg/modules/dri/swrast_dri.so: No such file or directory (search paths /usr/lib/xorg/modules/dri, suffix _dri)
libGL error: failed to load driver: swrast
 * Serving Flask app 'speculos.api.api' (lazy loading)
 * Environment: development
 * Debug mode: off
12:00:29.037:werkzeug: WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5000
 * Running on http://172.17.0.2:5000
```

Adding package `mesa-dri-gallium` to `ledger-app-dev-tools` docker container solves the errors