### PR TITLE
Add cargo ledger setup step to full / legacy images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2023-09-18
+
+### Added
+    - Add `cargo ledger setup` step in full/legacy images so users don't have to do it.
+
+### Changed
+    - Update curl installation step in full image (work around of https://github.com/curl/curl/issues/11917).
+    - Remove curl installation from dev-tools image (already installed in full image).
 
 ## [3.5.0] - 2023-09-18
 

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -6,7 +6,6 @@ RUN apk add libusb \
             py3-qt5 \
             qemu-arm \
             jq \
-            curl \
             tesseract-ocr \
             mesa-dri-gallium
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -4,7 +4,7 @@ ARG RUST_STABLE_VERSION=1.72.0
 ARG RUST_NIGHTLY_VERSION=nightly-2022-12-02
 
 # Add curl for Rust buildchain
-RUN apk add curl
+RUN apk add --update-cache --upgrade curl
 
 # Define rustup/cargo home directories
 ENV RUSTUP_HOME=/opt/rustup \
@@ -29,3 +29,6 @@ RUN rustup component add rust-src --toolchain $RUST_NIGHTLY_VERSION
 
 # Add cargo ledger (needs a version of Rust >= 1.70)
 RUN cargo +$RUST_STABLE_VERSION install --locked --git=https://github.com/LedgerHQ/cargo-ledger.git --rev 1.1.0 cargo-ledger
+
+# Setup cargo ledger (install JSON target files)
+RUN cargo ledger setup

--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -65,6 +65,9 @@ RUN rustup component add rust-src --toolchain $RUST_NIGHTLY_VERSION
 # Add cargo ledger (needs a version of Rust >= 1.70)
 RUN cargo +$RUST_STABLE_VERSION install --locked --git=https://github.com/LedgerHQ/cargo-ledger.git --rev 1.1.0 cargo-ledger
 
+# Setup cargo ledger (install JSON target files)
+RUN cargo ledger setup
+
 # Adding LLVM-15 APT repository and installing it
 RUN wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository -y "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"


### PR DESCRIPTION
- Add `cargo ledger setup` to full/legacy images so users don't have to do it before being able to build apps.
- Add workaround to `https://github.com/curl/curl/issues/11917` so that `curl` still works properly.
- Remove `apk add curl` from dev-tools image, it is already installed in full image.