### PR TITLE
update cargo-ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.1] - 2024-01-11
+
+### Changed
+    - Update cargo-ledger 
 
 ## [3.12.0] - 2024-01-10
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -38,7 +38,7 @@ RUN pip3 install ledgerwallet==0.4.0
 RUN apk del python_build_deps
 
 # Add cargo ledger (needs a version of Rust >= 1.70)
-RUN cargo +$RUST_STABLE_VERSION install --version 1.2.1 cargo-ledger
+RUN cargo +$RUST_STABLE_VERSION install --version 1.2.2 cargo-ledger
 
 # Setup cargo ledger (install JSON target files)
 RUN cargo ledger setup

--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -66,7 +66,7 @@ RUN rustup component add rust-src --toolchain $RUST_NIGHTLY_VERSION
 RUN pip3 install ledgerwallet==0.4.0
 
 # Add cargo ledger (needs a version of Rust >= 1.70)
-RUN cargo +$RUST_STABLE_VERSION install --version 1.2.1 cargo-ledger
+RUN cargo +$RUST_STABLE_VERSION install --version 1.2.2 cargo-ledger
 
 # Setup cargo ledger (install JSON target files)
 RUN cargo ledger setup


### PR DESCRIPTION
Update cargo-ledger so when building Rust applications local C SDK already cloned in containers (full, dev-tools) are used.