### PR TITLE
[update] Bump all SDK versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.0] - 2024-07-17
+
+### Changed
+    - Bump all devices SDK version
+
 ## [3.29.0] - 2024-07-16
 
 ### Changed

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -73,27 +73,27 @@ RUN git clone "$GIT_SERVER/ledger-secure-sdk.git" "$LEDGER_SECURE_SDK"
 
 # Latest Nano S SDK (OS nanos_2.1.0 => based on API_LEVEL LNS)
 ENV NANOS_SDK=/opt/nanos-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOS_SDK" lns-2.1.0-v22.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOS_SDK" lns-2.1.0-v22.1
 RUN echo nanos > $NANOS_SDK/.target
 
 # Latest Nano X SDK (OS nanox_2.2.4 => based on API_LEVEL 5)
 ENV NANOX_SDK=/opt/nanox-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOX_SDK" v5.13.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOX_SDK" v5.13.1
 RUN echo nanox > $NANOX_SDK/.target
 
 # Latest Nano S+ SDK (OS nanos+_1.1.2 => based on API_LEVEL 5)
 ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOSP_SDK" v5.13.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOSP_SDK" v5.13.1
 RUN echo nanos2 > $NANOSP_SDK/.target
 
 # Latest Stax SDK (OS stax_1.5.0 => based on API_LEVEL 21)
 ENV STAX_SDK=/opt/stax-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$STAX_SDK" v21.2.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$STAX_SDK" v21.2.1
 RUN echo stax > $STAX_SDK/.target
 
 # Latest Flex SDK (OS flex_1.1.0 => based on API_LEVEL 21)
 ENV FLEX_SDK=/opt/flex-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$FLEX_SDK" v21.2.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$FLEX_SDK" v21.2.1
 RUN echo flex > $FLEX_SDK/.target
 
 # Default SDK


### PR DESCRIPTION
The new SDK versions include a bugfix on the U2F transport layer.

This should not be merged until the following PR are merged:
- https://github.com/LedgerHQ/ledger-secure-sdk/pull/731
- https://github.com/LedgerHQ/ledger-secure-sdk/pull/732
- https://github.com/LedgerHQ/ledger-secure-sdk/pull/733
- https://github.com/LedgerHQ/ledger-secure-sdk/pull/734