### PR TITLE
Update SDKs to v22.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.48.0] - 2025-01-27
+
+### Changed
+    - Bump Speculos & Ragger versions
+    - Bump all devices SDK versions
+
 ## [3.47.0] - 2025-01-08
 
 ### Changed

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add $(echo -n "$PYTHON_BUILD_DEPS" | tr , ' ')
 RUN apk add imagemagick grep
 
 # Install test tools (Ragger framework, Speculos emulator, Ledgerblue...)
-RUN pip3 install --no-cache-dir "ragger[tests,all_backends]==1.24.0" "speculos==0.12.0"
+RUN pip3 install --no-cache-dir "ragger[tests,all_backends]==1.25.0" "speculos==0.13.1"
 
 # Add the enforcer script
 ADD ./dev-tools/enforcer.sh /opt/enforcer.sh

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -78,22 +78,22 @@ RUN echo nanos > $NANOS_SDK/.target
 
 # Latest Nano X SDK (OS nanox_2.4.0 => based on API_LEVEL 22)
 ENV NANOX_SDK=/opt/nanox-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOX_SDK" v22.0.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOX_SDK" v22.1.0
 RUN echo nanox > $NANOX_SDK/.target
 
 # Latest Nano S+ SDK (OS nanos+_1.3.0 => based on API_LEVEL 22)
 ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOSP_SDK" v22.0.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOSP_SDK" v22.1.0
 RUN echo nanos2 > $NANOSP_SDK/.target
 
 # Latest Stax SDK (OS stax_1.6.0 => based on API_LEVEL 22)
 ENV STAX_SDK=/opt/stax-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$STAX_SDK" v22.0.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$STAX_SDK" v22.1.0
 RUN echo stax > $STAX_SDK/.target
 
 # Latest Flex SDK (OS flex_1.2.0 => based on API_LEVEL 22)
 ENV FLEX_SDK=/opt/flex-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$FLEX_SDK" v22.0.0
+RUN git -C "$LEDGER_SECURE_SDK" worktree add "$FLEX_SDK" v22.1.0
 RUN echo flex > $FLEX_SDK/.target
 
 # Default SDK


### PR DESCRIPTION
Update the following SDK versions to v22.1.0
- NanoX
- NanoSP
- Stax
- Flex

Also bump the follwoing versions
- Ragger to v1.25.0
- Speculos to v0.13.1