### PR TITLE
Add ninja-build to the lite container image

### DIFF
--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -16,6 +16,7 @@ RUN apt install -y --no-install-recommends \
         lld \
         llvm \
         make \
+        ninja-build \
         protobuf-compiler \
         python3 \
         python3-pip


### PR DESCRIPTION
Following a discussion with @apaillier-ledger , this PR adds `ninja-build` to the lite image. The Ninja build system allow faster build with a better verbosity in case of error. This will be useful for testing/fuzzing and for building apps when switching from Make to CMake.