### PR TITLE
Move jq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.0] - 2025-xx-xx
+
+### Changed
+    - Moved jq installation from `full` image to `lite`
+
 ## [4.7.0] - 2025-06-02
 
 ### Changed

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -4,9 +4,7 @@ ENV RUST_STABLE=1.83.0
 ENV RUST_NIGHTLY=nightly-2024-12-01
 
 # Add curl for Rust buildchain
-RUN apt install -y --no-install-recommends \
-        curl \
-        jq
+RUN apt install -y --no-install-recommends curl
 
 # Define rustup/cargo home directories
 ENV RUSTUP_HOME=/opt/rustup

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -10,6 +10,7 @@ RUN apt install -y --no-install-recommends \
         doxygen \
         gcc-arm-none-eabi \
         git \
+        jq \
         libcmocka-dev \
         lcov \
         libnewlib-arm-none-eabi \


### PR DESCRIPTION
Move `jq` to `lite` image (for `reusable_build` workflow)