### PR TITLE
Adding picolibc (picolibc-aarch64-linux-gnu (1.8.10-2))

### DIFF
--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -14,6 +14,7 @@ RUN apt install -y --no-install-recommends \
         libcmocka-dev \
         lcov \
         libnewlib-arm-none-eabi \
+        picolibc-arm-none-eabi \
         lld \
         llvm \
         make \


### PR DESCRIPTION
As preparation for the SDK libs switch: https://ledgerhq.atlassian.net/browse/B2CA-1995