### PR TITLE
upgrade to clang 21

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -134,7 +134,6 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 
-
   dev_tools:
     name: App Developer Tools
     needs: [mods_list, check_changelog, builder, get_speculos_version]

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
+#FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
+FROM trixie-full-clang-21:latest
 
 ARG SPECULOS_VERSION
 
@@ -19,6 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libxkbcommon-x11-0 \
         python3-pyqt6 \
         qemu-user-static && \
+        autoconf && \
+        libtool  && \
      pip3 install --break-system-packages --no-cache-dir --no-binary speculos "speculos==${SPECULOS_VERSION}" && \
      apt-get clean && \
      rm -rf /var/lib/apt/lists/*

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -3,22 +3,22 @@ FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 ARG SPECULOS_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gcc-arm-linux-gnueabihf \
-        imagemagick \
-        libc6-dev-armhf-cross \
-        libgl1 \
-        libpython3-dev \
-        libvncserver-dev \
-        libxcb-icccm4 \
-        libxcb-image0 \
-        libxcb-keysyms1 \
-        libxcb-render-util0 \
-        libxcb-shape0 \
-        libxcb-xinerama0 \
-        libxcb-xkb1 \
-        libxkbcommon-x11-0 \
-        python3-pyqt6 \
-        qemu-user-static && \
+        gcc-arm-linux-gnueabihf=4:14.2.0-1 \
+        imagemagick=8:7.1.1.43+dfsg1-1+deb13u9 \
+        libc6-dev-armhf-cross=2.41-11cross1 \
+        libgl1=1.7.0-1+b2 \
+        libpython3-dev=3.13.5-1 \
+        libvncserver-dev=0.9.15+dfsg-1+deb13u1 \
+        libxcb-icccm4=0.4.2-1 \
+        libxcb-image0=0.4.0-2+b2 \
+        libxcb-keysyms1=0.4.1-1 \
+        libxcb-render-util0=0.3.10-1 \
+        libxcb-shape0=1.17.0-2+b1 \
+        libxcb-xinerama0=1.17.0-2+b1 \
+        libxcb-xkb1=1.17.0-2+b1 \
+        libxkbcommon-x11-0=1.7.0-2 \
+        python3-pyqt6=6.9.0-2 \
+        qemu-user-static=1:10.0.8+ds-0+deb13u1+b2 && \
      pip3 install --break-system-packages --no-cache-dir --no-binary speculos "speculos==${SPECULOS_VERSION}" && \
      apt-get clean && \
      rm -rf /var/lib/apt/lists/*

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -1,14 +1,14 @@
-FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
+# FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
+FROM ledger-app-builder-lite:latest
+#FROM trixie-lite-clang-21:latest
 
 ENV RUST_STABLE=1.92.0
 ENV RUST_NIGHTLY=nightly-2025-12-05
 
-RUN apt-get install -y --no-install-recommends \
-        curl \
-        python3-dev \
-        python3-pkgconfig \
-        python3-venv \
-        rsync
+# Add curl for Rust buildchain
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl python3-dev python3-pkgconfig python3-venv rsync && \
+    rm -rf /var/lib/apt/lists/*
 
 # Define rustup/cargo home directories
 ENV RUSTUP_HOME=/opt/rustup
@@ -39,3 +39,4 @@ RUN cargo +$RUST_NIGHTLY ledger setup -t custom_target_nightly
 
 # Make Rust directories readable and writable for all users (X adds execute only on directories)
 RUN chmod -R a+rwX $RUSTUP_HOME $CARGO_HOME
+

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -3,12 +3,13 @@ FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 ENV RUST_STABLE=1.92.0
 ENV RUST_NIGHTLY=nightly-2025-12-05
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         python3-dev \
         python3-pkgconfig \
         python3-venv \
-        rsync
+        rsync && \
+    rm -rf /var/lib/apt/lists/*
 
 # Define rustup/cargo home directories
 ENV RUSTUP_HOME=/opt/rustup

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -4,11 +4,11 @@ ENV RUST_STABLE=1.92.0
 ENV RUST_NIGHTLY=nightly-2025-12-05
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl \
-        python3-dev \
-        python3-pkgconfig \
-        python3-venv \
-        rsync && \
+        curl=8.14.1-2+deb13u3 \
+        python3-dev=3.13.5-1 \
+        python3-pkgconfig=1.5.5-3 \
+        python3-venv=3.13.5-1 \
+        rsync=3.4.1+ds1-5+deb13u3 && \
     rm -rf /var/lib/apt/lists/*
 
 # Define rustup/cargo home directories

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -1,21 +1,17 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
-RUN apt update && \
-    apt install -y --no-install-recommends \
-        clang \
-        clang-format \
-        clang-tools \
+ARG SDK_VERSION=4211d91290681e9eacabbfc6b7036b493602c14f
+ARG CLANG_VERSION=21
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
         cmake \
         doxygen \
-        gcc-arm-none-eabi \
         git \
         jq \
         lcov \
         libbsd-dev \
         libcmocka-dev \
-        libnewlib-arm-none-eabi \
-        lld \
-        llvm \
+        lcov \
         make \
         ninja-build \
         picolibc-arm-none-eabi \
@@ -23,47 +19,59 @@ RUN apt update && \
         protobuf-compiler \
         python3 \
         python3-pip \
-        python-is-python3
+        wget \
+        gcc-arm-none-eabi \
+        libnewlib-arm-none-eabi \
+        picolibc-arm-none-eabi \
+        gnupg
+
+# Install clang 21 toolchain
+RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-$CLANG_VERSION main" > /etc/apt/sources.list.d/llvm.list && \
+    echo "deb-src [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-$CLANG_VERSION main" >> /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends clang-$CLANG_VERSION clang-format-$CLANG_VERSION clang-tools-$CLANG_VERSION \
+                                           lld-$CLANG_VERSION llvm-$CLANG_VERSION && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/llvm-ranlib llvm-ranlib /usr/bin/llvm-ranlib-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/llvm-objcopy-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/llvm-nm llvm-nm /usr/bin/llvm-nm-$CLANG_VERSION 100 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Python package to load app onto device
 RUN pip3 install --break-system-packages --no-cache-dir "ledgerblue==0.1.55" tomli-w ledgered semver
 
 # Unified SDK
 ARG LEDGER_SECURE_SDK=/opt/ledger-secure-sdk
-RUN git clone "https://github.com/LedgerHQ/ledger-secure-sdk.git" "$LEDGER_SECURE_SDK"
+RUN git clone -b $SDK_VERSION --no-single-branch "https://github.com/LedgerHQ/ledger-secure-sdk.git" "$LEDGER_SECURE_SDK"
 
 # Latest Nano S SDK (OS nanos_2.1.0 => based on API_LEVEL LNS)
 ENV NANOS_SDK=/opt/nanos-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOS_SDK" lns-2.1.0-v24.0
-RUN echo nanos > $NANOS_SDK/.target
-
-# Latest Nano X SDK based on API_LEVEL 25
 ENV NANOX_SDK=/opt/nanox-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOX_SDK" v26.1.3
-RUN echo nanox > $NANOX_SDK/.target
-
-# Latest Nano S+ SDK based on API_LEVEL 25
 ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOSP_SDK" v26.1.3
-RUN echo nanos2 > $NANOSP_SDK/.target
-
-# Latest Stax SDK based on API_LEVEL 25
 ENV STAX_SDK=/opt/stax-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$STAX_SDK" v26.1.3
-RUN echo stax > $STAX_SDK/.target
-
-# Latest Flex SDK based on API_LEVEL 25
 ENV FLEX_SDK=/opt/flex-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$FLEX_SDK" v26.1.3
-RUN echo flex > $FLEX_SDK/.target
-
-# Latest Apex P SDK based on API_LEVEL 25
 ENV APEX_P_SDK=/opt/apex-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$APEX_P_SDK" v26.1.3
-RUN echo apex_p > $APEX_P_SDK/.target
 
 # Default SDK
 ENV BOLOS_SDK=$NANOSP_SDK
+
+RUN git -C "$LEDGER_SECURE_SDK" worktree add -d "$NANOS_SDK" lns-2.1.0-v24.0 && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$NANOX_SDK"  $SDK_VERSION && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$NANOSP_SDK" $SDK_VERSION && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$STAX_SDK"   $SDK_VERSION && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$FLEX_SDK"   $SDK_VERSION && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$APEX_P_SDK" $SDK_VERSION && \
+    echo nanos  > $NANOS_SDK/.target && \
+    echo nanox  > $NANOX_SDK/.target && \
+    echo nanos2 > $NANOSP_SDK/.target && \
+    echo stax   > $STAX_SDK/.target && \
+    echo flex   > $FLEX_SDK/.target && \
+    echo apex_p > $APEX_P_SDK/.target
 
 WORKDIR /app
 

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -1,29 +1,54 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
-RUN apt update && \
-    apt install -y --no-install-recommends \
-        clang \
-        clang-format \
-        clang-tools \
+ARG NANOSP_SDK_VERSION=v26.1.7
+ARG NANOX_SDK_VERSION=v26.1.7
+ARG STAX_SDK_VERSION=v26.1.7
+ARG FLEX_SDK_VERSION=v26.1.7
+ARG APEX_P_SDK_VERSION=v26.1.7
+
+ARG CLANG_VERSION=21
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
         cmake \
         doxygen \
         gcc-arm-none-eabi \
         git \
+        gnupg \
         jq \
         lcov \
         libbsd-dev \
         libcmocka-dev \
         libnewlib-arm-none-eabi \
-        lld \
-        llvm \
+        libtool \
         make \
         ninja-build \
         picolibc-arm-none-eabi \
         pkg-config \
         protobuf-compiler \
+        python-is-python3 \
         python3 \
         python3-pip \
-        python-is-python3
+        wget
+
+# Install clang 21 toolchain
+RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-$CLANG_VERSION main" > /etc/apt/sources.list.d/llvm.list && \
+    echo "deb-src [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-$CLANG_VERSION main" >> /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends clang-$CLANG_VERSION clang-format-$CLANG_VERSION clang-tools-$CLANG_VERSION \
+                                           lld-$CLANG_VERSION llvm-$CLANG_VERSION && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/llvm-ranlib llvm-ranlib /usr/bin/llvm-ranlib-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/llvm-objcopy-$CLANG_VERSION 100 && \
+    update-alternatives --install /usr/bin/llvm-nm llvm-nm /usr/bin/llvm-nm-$CLANG_VERSION 100 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Python package to load app onto device
 RUN pip3 install --break-system-packages --no-cache-dir "ledgerblue==0.1.55" tomli-w ledgered semver
@@ -34,36 +59,28 @@ RUN git clone "https://github.com/LedgerHQ/ledger-secure-sdk.git" "$LEDGER_SECUR
 
 # Latest Nano S SDK (OS nanos_2.1.0 => based on API_LEVEL LNS)
 ENV NANOS_SDK=/opt/nanos-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOS_SDK" lns-2.1.0-v24.0
-RUN echo nanos > $NANOS_SDK/.target
 
-# Latest Nano X SDK based on API_LEVEL 25
 ENV NANOX_SDK=/opt/nanox-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOX_SDK" v26.1.7
-RUN echo nanox > $NANOX_SDK/.target
-
-# Latest Nano S+ SDK based on API_LEVEL 25
 ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$NANOSP_SDK" v26.1.7
-RUN echo nanos2 > $NANOSP_SDK/.target
-
-# Latest Stax SDK based on API_LEVEL 25
 ENV STAX_SDK=/opt/stax-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$STAX_SDK" v26.1.7
-RUN echo stax > $STAX_SDK/.target
-
-# Latest Flex SDK based on API_LEVEL 25
 ENV FLEX_SDK=/opt/flex-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$FLEX_SDK" v26.1.7
-RUN echo flex > $FLEX_SDK/.target
-
-# Latest Apex P SDK based on API_LEVEL 25
 ENV APEX_P_SDK=/opt/apex-secure-sdk
-RUN git -C "$LEDGER_SECURE_SDK" worktree add "$APEX_P_SDK" v26.1.7
-RUN echo apex_p > $APEX_P_SDK/.target
 
 # Default SDK
 ENV BOLOS_SDK=$NANOSP_SDK
+
+RUN git -C "$LEDGER_SECURE_SDK" worktree add -d "$NANOS_SDK" lns-2.1.0-v24.0 && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$NANOX_SDK"  $NANOX_SDK_VERSION && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$NANOSP_SDK" $NANOSP_SDK_VERSION && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$STAX_SDK"   $STAX_SDK_VERSION && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$FLEX_SDK"   $FLEX_SDK_VERSION && \
+    git -C "$LEDGER_SECURE_SDK" worktree add -d "$APEX_P_SDK" $APEX_P_SDK_VERSION && \
+    echo nanos  > $NANOS_SDK/.target && \
+    echo nanox  > $NANOX_SDK/.target && \
+    echo nanos2 > $NANOSP_SDK/.target && \
+    echo stax   > $STAX_SDK/.target && \
+    echo flex   > $FLEX_SDK/.target && \
+    echo apex_p > $APEX_P_SDK/.target
 
 WORKDIR /app
 

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
 
 ARG NANOSP_SDK_VERSION=v26.1.7
 ARG NANOX_SDK_VERSION=v26.1.7
@@ -6,48 +6,49 @@ ARG STAX_SDK_VERSION=v26.1.7
 ARG FLEX_SDK_VERSION=v26.1.7
 ARG APEX_P_SDK_VERSION=v26.1.7
 
-ARG CLANG_VERSION=21
+ARG CLANG_MAJOR=21
+ARG CLANG_NIGHTLY=1:21.1.8~++20251221033036+2078da43e25a-1~exp1~20251221153213.50
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-        autoconf \
-        automake \
-        build-essential \
-        cmake \
-        doxygen \
-        gcc-arm-none-eabi \
-        git \
-        gnupg \
-        jq \
-        lcov \
-        libbsd-dev \
-        libcmocka-dev \
-        libnewlib-arm-none-eabi \
-        libtool \
-        make \
-        ninja-build \
-        picolibc-arm-none-eabi \
-        pkg-config \
-        protobuf-compiler \
-        python-is-python3 \
-        python3 \
-        python3-pip \
-        wget
+        autoconf=2.72-3.1 \
+        automake=1:1.17-4 \
+        build-essential=12.12 \
+        cmake=3.31.6-2 \
+        doxygen=1.9.8+ds-2.1 \
+        gcc-arm-none-eabi=15:14.2.rel1-1 \
+        git=1:2.47.3-0+deb13u1 \
+        gnupg=2.4.7-21+deb13u1 \
+        jq=1.7.1-6+deb13u2 \
+        lcov=2.3.1-1 \
+        libbsd-dev=0.12.2-2 \
+        libcmocka-dev=1.1.7-3+b1 \
+        libnewlib-arm-none-eabi=4.5.0.20241231-1 \
+        libtool=2.5.4-4 \
+        make=4.4.1-2 \
+        ninja-build=1.12.1-1 \
+        picolibc-arm-none-eabi=1.8.10-2 \
+        pkg-config=1.8.1-4 \
+        protobuf-compiler=3.21.12-11 \
+        python-is-python3=3.13.3-1 \
+        python3=3.13.5-1 \
+        python3-pip=25.1.1+dfsg-1 \
+        wget=1.25.0-2
 
 # Install clang 21 toolchain
 RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-$CLANG_VERSION main" > /etc/apt/sources.list.d/llvm.list && \
-    echo "deb-src [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-$CLANG_VERSION main" >> /etc/apt/sources.list.d/llvm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-$CLANG_MAJOR main" > /etc/apt/sources.list.d/llvm.list && \
+    echo "deb-src [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/trixie/ llvm-toolchain-trixie-$CLANG_MAJOR main" >> /etc/apt/sources.list.d/llvm.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends clang-$CLANG_VERSION clang-format-$CLANG_VERSION clang-tools-$CLANG_VERSION \
-                                           lld-$CLANG_VERSION llvm-$CLANG_VERSION && \
-    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VERSION 100 && \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$CLANG_VERSION 100 && \
-    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-$CLANG_VERSION 100 && \
-    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-$CLANG_VERSION 100 && \
-    update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-$CLANG_VERSION 100 && \
-    update-alternatives --install /usr/bin/llvm-ranlib llvm-ranlib /usr/bin/llvm-ranlib-$CLANG_VERSION 100 && \
-    update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/llvm-objcopy-$CLANG_VERSION 100 && \
-    update-alternatives --install /usr/bin/llvm-nm llvm-nm /usr/bin/llvm-nm-$CLANG_VERSION 100 && \
+    apt-get install -y --no-install-recommends clang-$CLANG_MAJOR=${CLANG_NIGHTLY} clang-format-$CLANG_MAJOR=${CLANG_NIGHTLY} clang-tools-$CLANG_MAJOR=${CLANG_NIGHTLY} \
+                                           lld-$CLANG_MAJOR=${CLANG_NIGHTLY} llvm-$CLANG_MAJOR=${CLANG_NIGHTLY} && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_MAJOR 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$CLANG_MAJOR 100 && \
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-$CLANG_MAJOR 100 && \
+    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-$CLANG_MAJOR 100 && \
+    update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-$CLANG_MAJOR 100 && \
+    update-alternatives --install /usr/bin/llvm-ranlib llvm-ranlib /usr/bin/llvm-ranlib-$CLANG_MAJOR 100 && \
+    update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/llvm-objcopy-$CLANG_MAJOR 100 && \
+    update-alternatives --install /usr/bin/llvm-nm llvm-nm /usr/bin/llvm-nm-$CLANG_MAJOR 100 && \
     rm -rf /var/lib/apt/lists/*
 
 # Python package to load app onto device


### PR DESCRIPTION
This PR upgrades toolchain to clang-21.
Since it better enforces ISO C, CI won't pass until related SDK PR gets merged : https://github.com/LedgerHQ/ledger-secure-sdk/pull/1566
Both PRs need to be merged for CI to pass.