### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# fallback owners
+* @LedgerHQ/embedded-apps


### PR DESCRIPTION
Add a CODEOWNERS file under .github/ with fallback owners set to @LedgerHQ/embedded-apps.