### PR TITLE
temporarily removing pins 

### DIFF
--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -3,22 +3,22 @@ FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 ARG SPECULOS_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gcc-arm-linux-gnueabihf=4:14.2.0-1 \
-        imagemagick=8:7.1.1.43+dfsg1-1+deb13u9 \
-        libc6-dev-armhf-cross=2.41-11cross1 \
-        libgl1=1.7.0-1+b2 \
-        libpython3-dev=3.13.5-1 \
-        libvncserver-dev=0.9.15+dfsg-1+deb13u1 \
-        libxcb-icccm4=0.4.2-1 \
-        libxcb-image0=0.4.0-2+b2 \
-        libxcb-keysyms1=0.4.1-1 \
-        libxcb-render-util0=0.3.10-1 \
-        libxcb-shape0=1.17.0-2+b1 \
-        libxcb-xinerama0=1.17.0-2+b1 \
-        libxcb-xkb1=1.17.0-2+b1 \
-        libxkbcommon-x11-0=1.7.0-2 \
-        python3-pyqt6=6.9.0-2 \
-        qemu-user-static=1:10.0.8+ds-0+deb13u1+b2 && \
+        gcc-arm-linux-gnueabihf \
+        imagemagick \
+        libc6-dev-armhf-cross \
+        libgl1 \
+        libpython3-dev \
+        libvncserver-dev \
+        libxcb-icccm4 \
+        libxcb-image0 \
+        libxcb-keysyms1 \
+        libxcb-render-util0 \
+        libxcb-shape0 \
+        libxcb-xinerama0 \
+        libxcb-xkb1 \
+        libxkbcommon-x11-0 \
+        python3-pyqt6 \
+        qemu-user-static && \
      pip3 install --break-system-packages --no-cache-dir --no-binary speculos "speculos==${SPECULOS_VERSION}" && \
      apt-get clean && \
      rm -rf /var/lib/apt/lists/*

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -4,11 +4,11 @@ ENV RUST_STABLE=1.92.0
 ENV RUST_NIGHTLY=nightly-2025-12-05
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl=8.14.1-2+deb13u3 \
-        python3-dev=3.13.5-1 \
-        python3-pkgconfig=1.5.5-3 \
-        python3-venv=3.13.5-1 \
-        rsync=3.4.1+ds1-5+deb13u3 && \
+        curl \
+        python3-dev \
+        python3-pkgconfig \
+        python3-venv \
+        rsync && \
     rm -rf /var/lib/apt/lists/*
 
 # Define rustup/cargo home directories

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -10,29 +10,29 @@ ARG CLANG_MAJOR=21
 ARG CLANG_NIGHTLY=1:21.1.8~++20251221033036+2078da43e25a-1~exp1~20251221153213.50
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-        autoconf=2.72-3.1 \
-        automake=1:1.17-4 \
-        build-essential=12.12 \
-        cmake=3.31.6-2 \
-        doxygen=1.9.8+ds-2.1 \
-        gcc-arm-none-eabi=15:14.2.rel1-1 \
-        git=1:2.47.3-0+deb13u1 \
-        gnupg=2.4.7-21+deb13u1 \
-        jq=1.7.1-6+deb13u2 \
-        lcov=2.3.1-1 \
-        libbsd-dev=0.12.2-2 \
-        libcmocka-dev=1.1.7-3+b1 \
-        libnewlib-arm-none-eabi=4.5.0.20241231-1 \
-        libtool=2.5.4-4 \
-        make=4.4.1-2 \
-        ninja-build=1.12.1-1 \
-        picolibc-arm-none-eabi=1.8.10-2 \
-        pkg-config=1.8.1-4 \
-        protobuf-compiler=3.21.12-11 \
-        python-is-python3=3.13.3-1 \
-        python3=3.13.5-1 \
-        python3-pip=25.1.1+dfsg-1 \
-        wget=1.25.0-2
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        doxygen \
+        gcc-arm-none-eabi \
+        git \
+        gnupg \
+        jq \
+        lcov \
+        libbsd-dev \
+        libcmocka-dev \
+        libnewlib-arm-none-eabi \
+        libtool \
+        make \
+        ninja-build \
+        picolibc-arm-none-eabi \
+        pkg-config \
+        protobuf-compiler \
+        python-is-python3 \
+        python3 \
+        python3-pip \
+        wget
 
 # Install clang 21 toolchain
 RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg && \


### PR DESCRIPTION
amd64 and arm64 versions are not always aligned.

Removing pins from debian packages to avoid docker buildx errors.
Leaving pins for clang toolchain which is mandatory, and versions are aligned between two archs :

```
(venv) root@d41b3bd0f477:/app# apt-cache policy clang-21
clang-21:
  Installed: 1:21.1.8~++20251221033036+2078da43e25a-1~exp1~20251221153213.50
  Candidate: 1:21.1.8~++20251221033036+2078da43e25a-1~exp1~20251221153213.50
  Version table:
 *** 1:21.1.8~++20251221033036+2078da43e25a-1~exp1~20251221153213.50 500
        500 https://apt.llvm.org/trixie llvm-toolchain-trixie-21/main amd64 Packages
        100 /var/lib/dpkg/status
(venv) root@d41b3bd0f477:/app# apt-cache policy clang-21:arm64
clang-21:arm64:
  Installed: (none)
  Candidate: 1:21.1.8~++20251221033036+2078da43e25a-1~exp1~20251221153213.50
  Version table:
     1:21.1.8~++20251221033036+2078da43e25a-1~exp1~20251221153213.50 500
        500 https://apt.llvm.org/trixie llvm-toolchain-trixie-21/main arm64 Packages
```