### PR TITLE
optimize app-builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.13] - 2026-06-15
+
+### Changed
+    - Optimized full/Dockerfile and dev-tools/Dockerfile
+
 ## [5.3.12] - 2026-06-11
 
 ### Changed

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -2,6 +2,15 @@ FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
 ARG SPECULOS_VERSION
 
+ENV VENV_PATH=/opt/venv
+ENV PIP_CACHE_DIR=/opt/venv/pip-cache
+
+# Add the enforcer script
+COPY ./dev-tools/enforcer.sh /opt/enforcer.sh
+
+# Create a system-wide python venv writeable for all users
+# Set pip cache directory to a writable location
+# Automatically activate venv for all users
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc-arm-linux-gnueabihf \
         imagemagick \
@@ -21,20 +30,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         qemu-user-static && \
      pip3 install --break-system-packages --no-cache-dir --no-binary speculos "speculos==${SPECULOS_VERSION}" && \
      apt-get clean && \
-     rm -rf /var/lib/apt/lists/*
-
-# Add the enforcer script
-COPY ./dev-tools/enforcer.sh /opt/enforcer.sh
-
-# Create a system-wide python venv writeable for all users
-ENV VENV_PATH=/opt/venv
-RUN python3 -m venv $VENV_PATH --system-site-packages && \
-    chmod -R a+rwX $VENV_PATH
-
-# Set pip cache directory to a writable location
-ENV PIP_CACHE_DIR=/opt/venv/pip-cache
-RUN mkdir -p $PIP_CACHE_DIR && chmod -R a+rwX $PIP_CACHE_DIR
-
-# Automatically activate venv for all users
-RUN echo 'source /opt/venv/bin/activate' >> /etc/bash.bashrc
+     rm -rf /var/lib/apt/lists/* && \
+     python3 -m venv $VENV_PATH --system-site-packages && \
+     chmod -R a+rwX $VENV_PATH && \
+     mkdir -p $PIP_CACHE_DIR && chmod -R a+rwX $PIP_CACHE_DIR && \
+     echo 'source /opt/venv/bin/activate' >> /etc/bash.bashrc
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 
-ENV RUST_STABLE=1.92.0
+ARG CARGO_LEDGER_VERSION=1.14.0
+
 ENV RUST_NIGHTLY=nightly-2025-12-05
 
 # Define rustup/cargo home directories
@@ -10,27 +11,20 @@ ENV CARGO_HOME=/opt/.cargo
 # Adding cargo binaries to PATH
 ENV PATH=${PATH}:${CARGO_HOME}/bin
 
-# Installing stable channel version RUST_STABLE
 # Installing nightly channel version RUST_NIGHTLY (for Rust applications).
-# add clippy and fmt to both toolchain
+# add clippy and fmt to toolchain
 # Adding ARMV6M target to the installed stable and nightly toolchains
 # Adding rust-src component to nightly and stable channels
 # Add cargo ledger
 # Setup cargo ledger (install JSON target files and custom link script) for nightly
 # Make Rust directories readable and writable for all users (X adds execute only on directories)
-
-RUN apt-get update && apt-get install -y --no-install-recommends curl python3-dev python3-pkgconfig python3-venv rsync rustup && rm -rf /var/lib/apt/lists/* && \
-    rustup toolchain install $RUST_STABLE --profile minimal && \
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev python3-pkgconfig python3-venv rsync rustup && rm -rf /var/lib/apt/lists/* && \
     rustup toolchain install $RUST_NIGHTLY --profile minimal && \
-    rustup component add clippy --toolchain "$RUST_STABLE" && \
     rustup component add clippy --toolchain "$RUST_NIGHTLY" && \
-    rustup component add rustfmt --toolchain "$RUST_STABLE" && \
     rustup component add rustfmt --toolchain "$RUST_NIGHTLY" && \
-    rustup target add thumbv6m-none-eabi --toolchain $RUST_STABLE && \
     rustup target add thumbv6m-none-eabi --toolchain $RUST_NIGHTLY && \
     rustup component add rust-src --toolchain "$RUST_NIGHTLY" && \
-    rustup component add rust-src --toolchain "$RUST_STABLE" && \
-    cargo install --version 1.14.0 cargo-ledger && \
+    cargo install --version $CARGO_LEDGER_VERSION cargo-ledger && \
     cargo +$RUST_NIGHTLY ledger setup -t custom_target_nightly && \
     chmod -R a+rwX $RUSTUP_HOME $CARGO_HOME
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -3,15 +3,6 @@ FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 ENV RUST_STABLE=1.92.0
 ENV RUST_NIGHTLY=nightly-2025-12-05
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl \
-        python3-dev \
-        python3-pkgconfig \
-        python3-venv \
-        rsync \
-        rustup && \
-    rm -rf /var/lib/apt/lists/*
-
 # Define rustup/cargo home directories
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/.cargo
@@ -20,24 +11,26 @@ ENV CARGO_HOME=/opt/.cargo
 ENV PATH=${PATH}:${CARGO_HOME}/bin
 
 # Installing stable channel version RUST_STABLE
-RUN rustup toolchain install $RUST_STABLE
-
 # Installing nightly channel version RUST_NIGHTLY (for Rust applications).
-RUN rustup toolchain install $RUST_NIGHTLY
-
+# add clippy and fmt to both toolchain
 # Adding ARMV6M target to the installed stable and nightly toolchains
-RUN rustup target add thumbv6m-none-eabi --toolchain $RUST_STABLE
-RUN rustup target add thumbv6m-none-eabi --toolchain $RUST_NIGHTLY
-
 # Adding rust-src component to nightly and stable channels
-RUN rustup component add rust-src --toolchain $RUST_NIGHTLY
-RUN rustup component add rust-src --toolchain $RUST_STABLE
-
 # Add cargo ledger
-RUN cargo install --version 1.14.0 cargo-ledger
-
 # Setup cargo ledger (install JSON target files and custom link script) for nightly
-RUN cargo +$RUST_NIGHTLY ledger setup -t custom_target_nightly
-
 # Make Rust directories readable and writable for all users (X adds execute only on directories)
-RUN chmod -R a+rwX $RUSTUP_HOME $CARGO_HOME
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl python3-dev python3-pkgconfig python3-venv rsync rustup && rm -rf /var/lib/apt/lists/* && \
+    rustup toolchain install $RUST_STABLE --profile minimal && \
+    rustup toolchain install $RUST_NIGHTLY --profile minimal && \
+    rustup component add clippy --toolchain "$RUST_STABLE" && \
+    rustup component add clippy --toolchain "$RUST_NIGHTLY" && \
+    rustup component add rustfmt --toolchain "$RUST_STABLE" && \
+    rustup component add rustfmt --toolchain "$RUST_NIGHTLY" && \
+    rustup target add thumbv6m-none-eabi --toolchain $RUST_STABLE && \
+    rustup target add thumbv6m-none-eabi --toolchain $RUST_NIGHTLY && \
+    rustup component add rust-src --toolchain "$RUST_NIGHTLY" && \
+    rustup component add rust-src --toolchain "$RUST_STABLE" && \
+    cargo install --version 1.14.0 cargo-ledger && \
+    cargo +$RUST_NIGHTLY ledger setup -t custom_target_nightly && \
+    chmod -R a+rwX $RUSTUP_HOME $CARGO_HOME
+


### PR DESCRIPTION
Keeping only one layer drastically improves the image size.


Also, as per https://rust-lang.github.io/rustup/concepts/profiles.html#profiles

docs shall not be embedded in the container :

```
(venv) root@a29fd100ad63:/opt/rustup/toolchains/nightly-2025-12-05-x86_64-unknown-linux-gnu/share# du -h . -d 1
32K     ./zsh
500K    ./man
741M    ./doc
(venv) root@a29fd100ad63:/opt/rustup/toolchains/1.92.0-x86_64-unknown-linux-gnu/share# du -h . -d 1
32K     ./zsh
500K    ./man
725M    ./doc
725M    .
```

The final image size is almost divided by two :

```
$ docker images
ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest                             284c1b9c41b2       11.4GB         2.39GB
trixie-full-clang-21-2:latest                                                             99b13096ee3e       6.13GB          1.6GB
```

Keeping only one rust toolchain further improves the image size, and doesn't break zondax app builds :

```
trixie-full-clang-21-3:latest                                                             98d9628544c2       5.16GB         1.37GB
```